### PR TITLE
Fix unused result

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -20,15 +20,22 @@ void enable_raw_mode(e_context* ctx) {
 }
 
 
+/* sigh */
+void write_wrapped(int file, const char* str, int len) {
+   ssize_t x = write(file, str, len);
+   (void) x; 
+}
+
+
 void e_die(const char* s) {
-  (void)write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
+  write_wrapped(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
   perror(s);
   exit(1);
 }
 
 
 void e_exit() {
-  (void)write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
+  write_wrapped(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
   exit(0);
 }
 
@@ -211,7 +218,7 @@ void e_clear_screen(e_context* ctx) {
   ansi_append(&ab, buf, strlen(buf));
   ansi_append(&ab, "?25h", 4);
 
-  (void)write(STDOUT_FILENO, ab.b, ab.len);
+  write_wrapped(STDOUT_FILENO, ab.b, ab.len);
   ab_free(&ab);
 }
 
@@ -1211,7 +1218,7 @@ e_context*  e_setup() {
   e_context* ctx = malloc(sizeof(e_context));
   if (tcgetattr(STDIN_FILENO, &ctx->orig) == -1) e_die("tcgetattr");
 
-  (void)write(STDOUT_FILENO, "\x1b""7\x1b[?47h", 8);
+  write_wrapped(STDOUT_FILENO, "\x1b""7\x1b[?47h", 8);
   e_get_win_size(ctx);
   enable_raw_mode(ctx);
   ctx->rx = 0;

--- a/src/editor.c
+++ b/src/editor.c
@@ -21,14 +21,14 @@ void enable_raw_mode(e_context* ctx) {
 
 
 void e_die(const char* s) {
-  write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
+  (void)write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
   perror(s);
   exit(1);
 }
 
 
 void e_exit() {
-  write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
+  (void)write(STDOUT_FILENO, "\x1b[2J\x1b[?47l\x1b""8", 12);
   exit(0);
 }
 
@@ -211,7 +211,7 @@ void e_clear_screen(e_context* ctx) {
   ansi_append(&ab, buf, strlen(buf));
   ansi_append(&ab, "?25h", 4);
 
-  write(STDOUT_FILENO, ab.b, ab.len);
+  (void)write(STDOUT_FILENO, ab.b, ab.len);
   ab_free(&ab);
 }
 
@@ -1211,7 +1211,7 @@ e_context*  e_setup() {
   e_context* ctx = malloc(sizeof(e_context));
   if (tcgetattr(STDIN_FILENO, &ctx->orig) == -1) e_die("tcgetattr");
 
-  write(STDOUT_FILENO, "\x1b""7\x1b[?47h", 8);
+  (void)write(STDOUT_FILENO, "\x1b""7\x1b[?47h", 8);
   e_get_win_size(ctx);
   enable_raw_mode(ctx);
   ctx->rx = 0;

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -23,7 +23,7 @@ void syntax_read_extensions(syntax* c, FILE* f, char* line) {
   regcomp(reg, line, REG_EXTENDED);
 
   while (fpeek(f) == ' ' || fpeek(f) == '\t') {
-    fgets(line, MAX_LINE_WIDTH, f);
+    (void)fgets(line, MAX_LINE_WIDTH, f);
     ln = strlen(line)-1;
     line[ln] = '\0'; // replace newline
     reg = realloc(reg, sizeof(regex_t) * ++regl);
@@ -52,7 +52,7 @@ void syntax_read_pattern(syntax* c, FILE* f, char* key, char* value) {
   if (err) exit(err);
 
   if (fpeek(f) == ' ' || fpeek(f) == '\t') {
-    fgets(line, MAX_LINE_WIDTH, f);
+    (void)fgets(line, MAX_LINE_WIDTH, f);
     char* l = strtriml(line);
     ln = strlen(l)-1;
     memmove(l+1, l, ln);

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -23,12 +23,13 @@ void syntax_read_extensions(syntax* c, FILE* f, char* line) {
   regcomp(reg, line, REG_EXTENDED);
 
   while (fpeek(f) == ' ' || fpeek(f) == '\t') {
-    (void)fgets(line, MAX_LINE_WIDTH, f);
-    ln = strlen(line)-1;
-    line[ln] = '\0'; // replace newline
-    reg = realloc(reg, sizeof(regex_t) * ++regl);
-    err = regcomp(&reg[regl-1], strtriml(line), REG_EXTENDED);
-    if (err) exit(err);
+    if (fgets(line, MAX_LINE_WIDTH, f)) {
+      ln = strlen(line)-1;
+      line[ln] = '\0'; // replace newline
+      reg = realloc(reg, sizeof(regex_t) * ++regl);
+      err = regcomp(&reg[regl-1], strtriml(line), REG_EXTENDED);
+      if (err) exit(err);
+    }
   }
   c->matchlen = regl;
   c->filematch = reg;
@@ -51,8 +52,7 @@ void syntax_read_pattern(syntax* c, FILE* f, char* key, char* value) {
   err = regcomp(&pat->pattern, value, REG_EXTENDED);
   if (err) exit(err);
 
-  if (fpeek(f) == ' ' || fpeek(f) == '\t') {
-    (void)fgets(line, MAX_LINE_WIDTH, f);
+  if ((fpeek(f) == ' ' || fpeek(f) == '\t') && fgets(line, MAX_LINE_WIDTH, f)) {
     char* l = strtriml(line);
     ln = strlen(l)-1;
     memmove(l+1, l, ln);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -7,7 +7,7 @@
 #include "colors.h"
 #include "util.h"
 
-#define MAX_LINE_WIDTH 512
+#define MAX_LINE_WIDTH 1025
 
 typedef struct pattern {
   regex_t pattern;


### PR DESCRIPTION
This PR fixes #11. It introduces the helper function `write_wrapped` to ignore warnings on certain versions of GCC/glibc and unused results.