### PR TITLE
feat: Adding the list of built-in for python 2.7 in the stx grammer

### DIFF
--- a/stx/python.stx
+++ b/stx/python.stx
@@ -1,8 +1,7 @@
 displayname: python
 extensions: .*\.py
 pragma: (from|import)
-keyword: (and|as|assert|break|continue|def|del|elif|else|except|exec|finally|for|global|if|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
-type: (class|int|tuple|id|float|str|unicode|list|dict)
-predefined: (print|True|False|None)
+keyword: (and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|global|if|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
+predefined: (abs|all|any|basestring|bin|bool|bytearray|callable|chr|classmethod|cmp|compile|complex|delattr|dict|dir|divmod|enumerate|eval|execfile|file|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isianstance|issubclass|iter|len|list|locals|long|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|raw_input|reduce|reload|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|type|tuple|unichr|unicode|vars|xrange|zip|__import__|True|False|None)
 comment: #.*$
 type: @[^\(]*


### PR DESCRIPTION
Added some more into `predefined` for python. Basically the entire list. 

I see that `int` `float` `dict` etc are declared in type. I am not sure this is right. Python does not have type. They are more `built-ins` for python. 

c.f. - https://docs.python.org/2/library/functions.html

What do you think?