### PR TITLE
clipboard: fix Linux compilation when Gnome isn't available

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -72,10 +72,11 @@ char* e_clipboard_paste() {
   return buffer;
 }
 
-#elif __unix__
-#ifdef gnome
+#elif defined(__unix__) && defined(gnome)
 #include <gtk/gtk.h>
+
 GtkClipboard *clipboard;
+
 void e_clipboard_copy(char* str){
 	clipboard = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 	gchar *clip_str = str;
@@ -86,7 +87,7 @@ char* e_clipboard_paste(){
 	clipboard = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 	return (char*)gtk_clipboard_wait_for_text(clipboard);
 }
-#endif
+
 #else
 
 void e_clipboard_copy(char* str) {}


### PR DESCRIPTION
This pull request addresses an error when compiling on Linux without Gnome due to missing definitions for `e_clipboard_copy` and `e_clipboard_paste`.

```sh
make
mkdir -p /home/user/.estx
cp stx/* /home/user/.estx
DE is ubuntu
mkdir -p bin/
cc main.c src/clipboard.c src/editor.c src/buffer.c src/util.c src/colors.c src/syntax.c -DSTXDIR=\"/home/user/.estx\" -o bin/e -Werror -Wall -g -fPIC -O2 -DNDEBUG -ftrapv -Wfloat-equal -Wundef -Wwrite-strings -Wuninitialized -pedantic -std=c11
/tmp/ccmLhwOf.o: In function `e_initial':
/home/usr/src/e/src/editor.c:509: undefined reference to `e_clipboard_copy'
/home/usr/src/e/src/editor.c:490: undefined reference to `e_clipboard_copy'
/home/usr/src/e/src/editor.c:512: undefined reference to `e_clipboard_paste'
collect2: error: ld returned 1 exit status
Makefile:25: recipe for target 'all' failed
make: *** [all] Error 1
```