### PR TITLE
lua: fix missing math library compilation error on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ ifeq ($(OS),$(filter $(OS), FreeBSD OpenBSD NetBSD))
 CADDFLAG += -lexecinfo
 endif
 
+ifeq ($(OS),$(filter $(OS),  Linux))
+CADDFLAG += -lm
+$(info CADDFLAG is $(CADDFLAG))
+endif
+
 ifeq ($(DE),gnome)
 CADDFLAG += `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
 DE_FLAG := -Dgnome


### PR DESCRIPTION
This change addresses an error compiling the Lua version on Linux, which is failing at the linking stage due to the missing floating-point math library (`-l m`).

```sh
make lua
# ... lines omitted ...
cc main.c src/clipboard.c src/editor.c src/buffer.c src/util.c src/colors.c src/syntax.c -DSTXDIR=\"/home/user/.estx\" -o bin/e -DWITH_LUA -L./vendor/lua-5.3.4/src -llua  -Werror -Wall -g -fPIC -O2 -DNDEBUG -ftrapv -Wfloat-equal -Wundef -Wwrite-strings -Wuninitialized -pedantic -std=c11  
./vendor/lua-5.3.4/src/liblua.a(loslib.o): In function `os_tmpname':
loslib.c:(.text+0x29d): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
./vendor/lua-5.3.4/src/liblua.a(lobject.o): In function `numarith.isra.0':
lobject.c:(.text+0x1d3): undefined reference to `fmod'
lobject.c:(.text+0x201): undefined reference to `pow'
lobject.c:(.text+0x215): undefined reference to `floor'
./vendor/lua-5.3.4/src/liblua.a(lvm.o): In function `luaV_tointeger':
lvm.c:(.text+0x2b7): undefined reference to `floor'
./vendor/lua-5.3.4/src/liblua.a(lvm.o): In function `luaV_execute':
lvm.c:(.text+0x1f0d): undefined reference to `floor'
lvm.c:(.text+0x2027): undefined reference to `fmod'
lvm.c:(.text+0x2684): undefined reference to `pow'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_log10':
lmathlib.c:(.text+0x9f): undefined reference to `log10'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_pow':
lmathlib.c:(.text+0x1b4): undefined reference to `pow'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_tanh':
lmathlib.c:(.text+0x1df): undefined reference to `tanh'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_sinh':
lmathlib.c:(.text+0x20f): undefined reference to `sinh'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_cosh':
lmathlib.c:(.text+0x23f): undefined reference to `cosh'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_tan':
lmathlib.c:(.text+0x26f): undefined reference to `tan'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_sqrt':
lmathlib.c:(.text+0x2ce): undefined reference to `sqrt'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_sin':
lmathlib.c:(.text+0x2ef): undefined reference to `sin'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_log':
lmathlib.c:(.text+0x631): undefined reference to `log'
lmathlib.c:(.text+0x645): undefined reference to `log'
lmathlib.c:(.text+0x676): undefined reference to `log10'
lmathlib.c:(.text+0x686): undefined reference to `log'
lmathlib.c:(.text+0x696): undefined reference to `log2'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_exp':
lmathlib.c:(.text+0x6ef): undefined reference to `exp'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_cos':
lmathlib.c:(.text+0x71f): undefined reference to `cos'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_atan':
lmathlib.c:(.text+0x77c): undefined reference to `atan2'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_asin':
lmathlib.c:(.text+0x7af): undefined reference to `asin'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_acos':
lmathlib.c:(.text+0x7df): undefined reference to `acos'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_ceil':
lmathlib.c:(.text+0x890): undefined reference to `ceil'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_modf':
lmathlib.c:(.text+0x8f3): undefined reference to `floor'
lmathlib.c:(.text+0x971): undefined reference to `ceil'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_floor':
lmathlib.c:(.text+0x9a0): undefined reference to `floor'
./vendor/lua-5.3.4/src/liblua.a(lmathlib.o): In function `math_fmod':
lmathlib.c:(.text+0xb0f): undefined reference to `fmod'
collect2: error: ld returned 1 exit status
Makefile:25: recipe for target 'all' failed
make[1]: *** [all] Error 1
make[1]: Leaving directory '/home/user/src/e'
Makefile:30: recipe for target 'lua' failed
make: *** [lua] Error 2
```