### PR TITLE
Graceful exit on syntax error in highlighting

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@ void handler(int sig) {
 void exitf() {
   disable_raw_mode(GLOB);
   e_context_free(GLOB);
-  if (stx) syntax_free(stx);
+  if (stx) syntaxes_free(stx);
 #ifdef WITH_LUA
   if (l) e_lua_free();
 #endif
@@ -37,6 +37,10 @@ void exitf() {
 
 int main(int argc, char** argv) {
   stx = syntax_init((char*) STXDIR);
+  if (!stx) {
+    fputs("Failed to initialize e: couldn’t read syntax files.\n", stderr);
+    return 1;
+  }
   GLOB = e_setup();
 
   signal(SIGSEGV, handler);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -26,4 +26,5 @@ typedef struct syntax {
 } syntax;
 
 syntax** syntax_init(char*);
-void syntax_free(syntax**);
+void syntax_free(syntax*);
+void syntaxes_free(syntax**);


### PR DESCRIPTION
This PR addresses the issue raised in #33. It prints a helpful (?) error message on encountering an error in the syntax highlighting and makes sure we clean up after ourselves—that is, don’t leak any memory.

I’ve tested both the error and success modes and did some superficial scanning with Valgrind: everything seems to be in order.